### PR TITLE
Re-adding newLine to line read in getStringContent

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/scripttrigger/ScriptTriggerExecutor.java
+++ b/src/main/java/org/jenkinsci/plugins/scripttrigger/ScriptTriggerExecutor.java
@@ -63,7 +63,7 @@ public class ScriptTriggerExecutor implements Serializable {
                     BufferedReader bufferedReader = new BufferedReader(fileReader);
                     String line;
                     while ((line = bufferedReader.readLine()) != null) {
-                        content.append(line);
+                        content.append(line + "\n");
                     }
                     return content.toString();
                 }


### PR DESCRIPTION
Line 65: line = bufferedReader.readLine() does not include line terminators
Suggested Fix on line 66: re-add the newLine

Current behavior puts all lines in a script file on one line.
