### PR TITLE
JENKINS-31017: Description doesn't get the resolved variable

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/scripttrigger/AbstractTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/scripttrigger/AbstractTrigger.java
@@ -84,7 +84,11 @@ public abstract class AbstractTrigger extends org.jenkinsci.lib.xtrigger.Abstrac
     }
 
     private String extractDescription(String content) {
-        return StringUtils.substringBetween(content, "<description>", "</description>");
+        String [] des =  StringUtils.substringsBetween(content, "<description>", "</description>");
+        if (des != null && des.length >=1 ) {
+            return des[des.length - 1];
+        }
+        return null;
     }
 
     protected boolean requiresWorkspaceForPolling() {


### PR DESCRIPTION
Chaning the description method to take the last occurance of given tags in the content
In this case user would be able to set the description with variables