### PR TITLE
Bugfix: NullPointerException during scheduled polling

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/scripttrigger/groovy/GroovyScriptTriggerExecutor.java
+++ b/src/main/java/org/jenkinsci/plugins/scripttrigger/groovy/GroovyScriptTriggerExecutor.java
@@ -81,11 +81,15 @@ public class GroovyScriptTriggerExecutor extends ScriptTriggerExecutor {
     }
 
     private boolean evaluateGroovyScript(final AbstractProject proj, final String scriptContent, final Map<String, String> envVars) {
-        final StringBuilder envDebug = new StringBuilder("Replacing script vars using:");
-        for (final Map.Entry<String, String> envEntry : envVars.entrySet()) {
-            envDebug.append("\n\t").append(envEntry.getKey()).append("=").append(envEntry.getValue());
+        if (envVars != null) {
+            final StringBuilder envDebug = new StringBuilder("Replacing script vars using:");
+            for (final Map.Entry<String, String> envEntry : envVars.entrySet()) {
+                envDebug.append("\n\t").append(envEntry.getKey()).append("=").append(envEntry.getValue());
+            }
+            log.info(envDebug.toString());
+        } else {
+            log.info("No environment variables available.");
         }
-        log.info(envDebug.toString());
 
         log.info("Evaluating the groovy script:");
         log.info("---------- Base Script -----------------");


### PR DESCRIPTION
```
Polling on master.
Running as node script
Script execition failed: java.lang.NullPointerException
java.lang.NullPointerException
	at org.jenkinsci.plugins.scripttrigger.groovy.GroovyScriptTriggerExecutor.evaluateGroovyScript(GroovyScriptTriggerExecutor.java:85)
	at org.jenkinsci.plugins.scripttrigger.groovy.GroovyScriptTriggerExecutor.access$100(GroovyScriptTriggerExecutor.java:45)
	at org.jenkinsci.plugins.scripttrigger.groovy.GroovyScriptTriggerExecutor$1.call(GroovyScriptTriggerExecutor.java:65)
	at org.jenkinsci.plugins.scripttrigger.groovy.GroovyScriptTriggerExecutor$1.call(GroovyScriptTriggerExecutor.java:62)
	at hudson.FilePath.act(FilePath.java:1163)
	at org.jenkinsci.plugins.scripttrigger.groovy.GroovyScriptTriggerExecutor.evaluateGroovyScript(GroovyScriptTriggerExecutor.java:62)
	at org.jenkinsci.plugins.scripttrigger.groovy.GroovyScriptTrigger.checkIfModified(GroovyScriptTrigger.java:180)
	at org.jenkinsci.lib.xtrigger.AbstractTrigger$Runner.run(AbstractTrigger.java:202)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
[ERROR] - Polling error...
```