### PR TITLE
Fix job parameters definition.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@ THE SOFTWARE.
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>1.424</version>
+        <version>1.579</version>
     </parent>
 
     <artifactId>scripttrigger</artifactId>
@@ -69,6 +69,16 @@ THE SOFTWARE.
             <groupId>org.jenkins-ci.lib</groupId>
             <artifactId>xtrigger-lib</artifactId>
             <version>${xtrigger.lib.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>matrix-project</artifactId>
+            <version>1.4</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>parameterized-scheduler</artifactId>
+            <version>0.2</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
In this plugin default values of job parameters
are not overriden but new parameters of String type are created.

Mechanism that replaces currently used one was borrowed from plugin https://github.com/jenkinsci/parameterized-scheduler-plugin

Jenkins Plugin version was updated here and dependencies that had been moved out of Jenkins Core to separate plugins were added.